### PR TITLE
Added solid.authing.cn

### DIFF
--- a/services.json
+++ b/services.json
@@ -32,6 +32,17 @@
 			"description": "solidtest.space is a public test server for Solid.",
 			"btn_bg": "#43C47A",
 			"btn_color": "#fff"
-		}
+		},
+		{
+			"url": "https://solid.authing.cn/",
+			"icon": "https://usercontents.authing.cn/client/logo@2.png",
+			"icon_bg": "#333748",
+			"title": "solid.authing",
+			"title_color": "#fff",
+			"policyURL": "https://solid.authing.cn",
+			"description": "solid.authing is a public solid server deployed in China",
+			"btn_bg": "#43C47A",
+			"btn_color": "#fff"
+		}		
 	]
 }


### PR DESCRIPTION
[solid.authing.cn](https://solid.authing.cn) is a public solid server deployed in China.

Maintained by [Learn Solid](https://learnsolid.cn) - a Chinese team.